### PR TITLE
fix for plc Optimus Drive

### DIFF
--- a/svc/controller-modbus/src/modbus.rs
+++ b/svc/controller-modbus/src/modbus.rs
@@ -197,6 +197,42 @@ async fn set_reg(
                         (u16::from(b[6]) << 8) + u16::from(b[7]),
                     ]
                 }
+                ModbusType::Uint32w => {
+                    let val: u32 = value.try_into()?;
+                    let b = val.to_be_bytes();
+                    vec![
+                        (u16::from(b[2]) << 8) + u16::from(b[3]),
+                        (u16::from(b[0]) << 8) + u16::from(b[1]),
+                    ]
+                }
+                ModbusType::Int32w => {
+                    let val: i32 = value.try_into()?;
+                    let b = val.to_be_bytes();
+                    vec![
+                        (u16::from(b[2]) << 8) + u16::from(b[3]),
+                        (u16::from(b[0]) << 8) + u16::from(b[1]),
+                    ]
+                }
+                ModbusType::Uint64w => {
+                    let val: u64 = value.try_into()?;
+                    let b = val.to_be_bytes();
+                    vec![
+                        (u16::from(b[6]) << 8) + u16::from(b[7]),
+                        (u16::from(b[4]) << 8) + u16::from(b[5]),
+                        (u16::from(b[2]) << 8) + u16::from(b[3]),
+                        (u16::from(b[0]) << 8) + u16::from(b[1]),
+                    ]
+                }
+                ModbusType::Int64w => {
+                    let val: i64 = value.try_into()?;
+                    let b = val.to_be_bytes();
+                    vec![
+                        (u16::from(b[6]) << 8) + u16::from(b[7]),
+                        (u16::from(b[4]) << 8) + u16::from(b[5]),
+                        (u16::from(b[2]) << 8) + u16::from(b[3]),
+                        (u16::from(b[0]) << 8) + u16::from(b[1]),
+                    ]
+                }
                 ModbusType::Real32 => {
                     let val: f32 = value.try_into()?;
                     #[allow(clippy::cast_possible_truncation)]
@@ -408,6 +444,58 @@ pub fn parse_block_value(
                 v3 as u8,
                 (v4 >> 8) as u8,
                 v4 as u8,
+            ]))
+        }
+        ModbusType::Uint32w => {
+            let v1 = get!(offset);
+            let v2 = get!(offset + 1);
+            Value::U32(u32::from_be_bytes([
+                (v2 >> 8) as u8,
+                v2 as u8,
+                (v1 >> 8) as u8,
+                v1 as u8,
+            ]))
+        }
+        ModbusType::Int32w => {
+            let v1 = get!(offset);
+            let v2 = get!(offset + 1);
+            Value::I32(i32::from_be_bytes([
+                (v2 >> 8) as u8,
+                v2 as u8,
+                (v1 >> 8) as u8,
+                v1 as u8,
+            ]))
+        }
+        ModbusType::Uint64w => {
+            let v1 = get!(offset);
+            let v2 = get!(offset + 1);
+            let v3 = get!(offset + 2);
+            let v4 = get!(offset + 3);
+            Value::U64(u64::from_be_bytes([
+                (v4 >> 8) as u8,
+                v4 as u8,
+                (v3 >> 8) as u8,
+                v3 as u8,
+                (v2 >> 8) as u8,
+                v2 as u8,
+                (v1 >> 8) as u8,
+                v1 as u8,
+            ]))
+        }
+        ModbusType::Int64w => {
+            let v1 = get!(offset);
+            let v2 = get!(offset + 1);
+            let v3 = get!(offset + 2);
+            let v4 = get!(offset + 3);
+            Value::I64(i64::from_be_bytes([
+                (v4 >> 8) as u8,
+                v4 as u8,
+                (v3 >> 8) as u8,
+                v3 as u8,
+                (v2 >> 8) as u8,
+                v2 as u8,
+                (v1 >> 8) as u8,
+                v1 as u8,
             ]))
         }
         ModbusType::Real32 => {

--- a/svc/controller-modbus/src/types.rs
+++ b/svc/controller-modbus/src/types.rs
@@ -39,6 +39,14 @@ pub enum ModbusType {
     Uint64,
     #[serde(alias = "sint64", alias = "LINT")]
     Int64,
+    #[serde(alias = "dwordw", alias = "UDINTW")]
+    Uint32w,
+    #[serde(alias = "sint32w", alias = "DINTW")]
+    Int32w,
+    #[serde(alias = "qwordw", alias = "ULINTW")]
+    Uint64w,
+    #[serde(alias = "sint64w", alias = "LINTW")]
+    Int64w,
     #[serde(alias = "real", alias = "REAL")]
     Real32,
     #[serde(alias = "LREAL")]
@@ -53,8 +61,18 @@ impl ModbusType {
     pub fn size(self) -> u16 {
         match self {
             ModbusType::Bit | ModbusType::Uint16 | ModbusType::Int16 => 1,
-            ModbusType::Uint32 | ModbusType::Int32 | ModbusType::Real32 | ModbusType::Real32b => 2,
-            ModbusType::Uint64 | ModbusType::Int64 | ModbusType::Real64 | ModbusType::Real64b => 4,
+            ModbusType::Uint32
+            | ModbusType::Int32
+            | ModbusType::Uint32w
+            | ModbusType::Int32w
+            | ModbusType::Real32
+            | ModbusType::Real32b => 2,
+            ModbusType::Uint64
+            | ModbusType::Int64
+            | ModbusType::Uint64w
+            | ModbusType::Int64w
+            | ModbusType::Real64
+            | ModbusType::Real64b => 4,
         }
     }
     #[inline]
@@ -63,10 +81,10 @@ impl ModbusType {
             ModbusType::Bit => Value::U8(value.try_into()?),
             ModbusType::Uint16 => Value::U16(value.try_into()?),
             ModbusType::Int16 => Value::I16(value.try_into()?),
-            ModbusType::Uint32 => Value::U32(value.try_into()?),
-            ModbusType::Int32 => Value::I32(value.try_into()?),
-            ModbusType::Uint64 => Value::U64(value.try_into()?),
-            ModbusType::Int64 => Value::I64(value.try_into()?),
+            ModbusType::Uint32 | ModbusType::Uint32w => Value::U32(value.try_into()?),
+            ModbusType::Int32 | ModbusType::Int32w => Value::I32(value.try_into()?),
+            ModbusType::Uint64 | ModbusType::Uint64w => Value::U64(value.try_into()?),
+            ModbusType::Int64 | ModbusType::Int64w => Value::I64(value.try_into()?),
             ModbusType::Real32 | ModbusType::Real32b => Value::F32(value.try_into()?),
             ModbusType::Real64 | ModbusType::Real64b => Value::F64(value.try_into()?),
         })


### PR DESCRIPTION
I have a Chinese AT16S0T-RU Optimus Drive PLC with reverse register order. I added support for this behavior to the Modbus controller.